### PR TITLE
Batching our Kafka messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ protobuf==4.22.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
+pydantic==1.10.6
 PyDispatcher==2.0.7
 pyOpenSSL==23.0.0
 python-dateutil==2.8.2


### PR DESCRIPTION
Turns out firing thousands of requests per second is not a good idea, and expensive to boot. 

- Batches our Kafka commits to fire batches of size 100
- Adding max page limit of 20 per profile scrapes. I think we have a good idea of you by then...